### PR TITLE
Reuse papertrail transport

### DIFF
--- a/src/apiGateway.js
+++ b/src/apiGateway.js
@@ -53,6 +53,7 @@ function constructTransport(event, callback){
 
     program = program.join("_");
 
+    // Build a dictionary of hostname and programs
     if(!(hostname in transports)){
       transports[hostname] = {};
     }
@@ -71,6 +72,8 @@ function constructTransport(event, callback){
           return message;
         }
       });
+      // Store the transport globally
+      transports[hostname][program] = papertrail
     }
 
     // post the logs

--- a/src/apiGateway.js
+++ b/src/apiGateway.js
@@ -7,6 +7,7 @@ var winston = require('winston');
 require('winston-papertrail').Papertrail;
 
 var restApis;
+var transports = {};
 
 // Handler function
 exports.handler = function(event, context, callback){
@@ -44,6 +45,7 @@ function constructTransport(event, callback){
 
     // Construct the program name from the log group name
     var program = data.logGroup.split("_").splice(1).join("_").split("/");
+    var hostname = "API-Gateway_" + data.owner + "_" + process.env.AWS_REGION;
 
     // If possible, replace the api ID with it's name
     if(restApis && restApis[program[0]])
@@ -51,16 +53,26 @@ function constructTransport(event, callback){
 
     program = program.join("_");
 
-    // Construct the winston transport for forwarding lambda logs to papertrail
-    var papertrail = new winston.transports.Papertrail({
-      host: config.host,
-      port: config.port,
-      hostname: "API-Gateway_" + data.owner + "_" + process.env.AWS_REGION,
-      program: program,
-      logFormat: function(level, message){
-        return message;
-      }
-    });
+    if(!(hostname in transports)){
+      transports[hostname] = {};
+    }
+
+    var papertrail;
+    if(program in transports[hostname]){
+      papertrail = transports[hostname][program]
+    }else{
+      // Construct the winston transport for forwarding lambda logs to papertrail
+      papertrail = new winston.transports.Papertrail({
+        host: config.host,
+        port: config.port,
+        hostname: hostname,
+        program: program,
+        logFormat: function(level, message){
+          return message;
+        }
+      });
+    }
+
     // post the logs
     logger.post(data, papertrail, callback);
   });

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -17,6 +17,7 @@ exports.handler = function(event, context, callback){
     var hostname = "Lambda_" + data.owner + "_" + process.env.AWS_REGION;
     var program = data.logGroup.split('/').pop();
 
+    // Build a dictionary of hostname and programs
     if(!(hostname in transports)){
       transports[hostname] = {};
     }
@@ -36,6 +37,8 @@ exports.handler = function(event, context, callback){
           return message;
         }
       });
+      // Store the transport globally
+      transports[hostname][program] = papertrail
     }
     // post the logs
     logger.post(data, papertrail, callback);

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -4,6 +4,8 @@ var logger = require('./lib/logger');
 var winston = require('winston');
 require('winston-papertrail').Papertrail;
 
+var transports = {};
+
 // Handler function
 exports.handler = function(event, context, callback){
 
@@ -12,17 +14,29 @@ exports.handler = function(event, context, callback){
     if(err)
       return callback(err);
 
-    // Construct the winston transport for forwarding lambda logs to papertrail
-    var papertrail = new winston.transports.Papertrail({
-      level: 'silly',
-      host: config.host,
-      port: config.port,
-      hostname: "Lambda_" + data.owner + "_" + process.env.AWS_REGION,
-      program: data.logGroup.split('/').pop(),
-      logFormat: function(level, message){
-        return message;
-      }
-    });
+    var hostname = "Lambda_" + data.owner + "_" + process.env.AWS_REGION;
+    var program = data.logGroup.split('/').pop();
+
+    if(!(hostname in transports)){
+      transports[hostname] = {};
+    }
+
+    var papertrail;
+    if(program in transports[hostname]){
+      papertrail = transports[hostname][program]
+    }else{
+      // Construct the winston transport for forwarding lambda logs to papertrail
+      papertrail = new winston.transports.Papertrail({
+        level: 'silly',
+        host: config.host,
+        port: config.port,
+        hostname: hostname,
+        program: program,
+        logFormat: function (level, message){
+          return message;
+        }
+      });
+    }
     // post the logs
     logger.post(data, papertrail, callback);
   });


### PR DESCRIPTION
## Purpose

- Storing the transport objects at the global level enables them to be reused between lambda invocations.
- Each lambda invocation will not require a new streaming connection to PaperTrail
